### PR TITLE
奨学金ページでの余分な空白の削除，リストが背景から溢れてしまうのを修正

### DIFF
--- a/src/app/scholarships/page.tsx
+++ b/src/app/scholarships/page.tsx
@@ -51,8 +51,8 @@ const ScholarshipsPage = async ({
           奨学金一覧({scholarships.length}件)
         </p>
       </div>
-      <div className="h-full flex justify-center">
-        <ul className="w-3/4 md:w-2/3 xl:w-1/2 flex flex-col justify-center gap-5 mb-10">
+      <div className="h-fit flex justify-center">
+        <ul className="w-3/4 md:w-2/3 xl:w-1/2 flex flex-col gap-5 mb-10">
           {scholarships.map((row, index) => (
             <Card key={row.id} className="border shadow-2xl">
               <CardHeader>


### PR DESCRIPTION
ISSUE: https://github.com/acu4git/gimme-scholarship-front/issues/6

## 修正点
- 奨学金リストの親divのclassNameにh-fullではなくh-fitを当てることで枠からのはみ出しを防ぐ
- 奨学金リストのulにもjustify-centerが当てられていたので削除

## UI
### 上部
<img width="1919" height="908" alt="スクリーンショット 2025-07-19 120654" src="https://github.com/user-attachments/assets/392ae865-82e3-41ba-ae60-d2088a707aa3" />

### 下部
<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/6fa36c65-f5ae-4fc3-8367-20d4e145c9cb" />
